### PR TITLE
feat(docker): use cache for image build

### DIFF
--- a/.github/workflows/dev-build-image.yaml
+++ b/.github/workflows/dev-build-image.yaml
@@ -9,9 +9,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build the Docker image
-        run: docker build . -f Dockerfile -t ghcr.io/sparcs-kaist/zabo-front:dev
-      - name: Log in to DockerHub
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Log in to Github Container Registry
         run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u USERNAME --password-stdin
-      - name: Push the Docker image
-        run: docker push ghcr.io/sparcs-kaist/zabo-front:dev
+      - name: Build and push Image
+        id: docker-build
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_TAG: dev
+        with:
+          push: true
+          tags: "ghcr.io/sparcs-kaist/zabo-front:${{ env.IMAGE_TAG }}"
+          # (3)
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Remove old cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #166 
front 이미지 빌드 시 캐시를 도입합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

빌드 후 스크린샷 추가 예정.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 릴리스 태그 생성 시 프로덕션 서버에 배포하기
