### PR TITLE
[Bug] dev deploy action 실패 시 기존 컨테이너 정지됨

### DIFF
--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -14,17 +14,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - name: executing remote ssh commands using password
+      - name: pull the image and restart the container
         uses: appleboy/ssh-action@v1.0.0
         with:
-          host: ${{ secrets.HOST }}
-          port: ${{ secrets.PORT }}
-          username: ${{ secrets.USERNAME }}
-          password: ${{ secrets.PASSWORD }}
-          proxy_host: ${{ secrets.PROXY_HOST }}
-          proxy_port: ${{ secrets.PROXY_PORT }}
-          proxy_username: ${{ secrets.PROXY_USERNAME }}
-          proxy_password: ${{ secrets.PROXY_PASSWORD }}
+          host: ${{ secrets.DEV_HOST }}
+          port: ${{ secrets.DEV_PORT }}
+          username: ${{ secrets.DEV_USERNAME }}
+          password: ${{ secrets.DEV_PASSWORD }}
+          proxy_host: ${{ secrets.DEV_PROXY_HOST }}
+          proxy_port: ${{ secrets.DEV_PROXY_PORT }}
+          proxy_username: ${{ secrets.DEV_PROXY_USERNAME }}
+          proxy_password: ${{ secrets.DEV_PROXY_PASSWORD }}
+          script_stop: true # stop script if any command has failed
           script: |
             docker pull ghcr.io/sparcs-kaist/zabo-front:dev
             docker rm -f zabo-front


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #169 

아래 cd pipeline에서 docker pull 명령이 실패했을 때 다음 커맨드들이 계속 실행되어 기존 컨테이너가 종료되는 문제가 발생합니다.
`script_stop: true` 옵션을 넣어 docker pull 명령이 실패했을 때 다음 커맨드들이 실행되지 않게 합니다.


```yaml
      - name: executing remote ssh commands using password
        uses: appleboy/ssh-action@v1.0.0
        with:
          host: ${{ secrets.HOST }}
          port: ${{ secrets.PORT }}
          username: ${{ secrets.USERNAME }}
          password: ${{ secrets.PASSWORD }}
          proxy_host: ${{ secrets.PROXY_HOST }}
          proxy_port: ${{ secrets.PROXY_PORT }}
          proxy_username: ${{ secrets.PROXY_USERNAME }}
          proxy_password: ${{ secrets.PROXY_PASSWORD }}
++++++    script_stop: true  
          script: |
            docker pull ghcr.io/sparcs-kaist/zabo-front:dev
            docker rm -f zabo-front
            docker run --restart always -d -p 15081:80 --name zabo-front ghcr.io/sparcs-kaist/zabo-front:dev
```

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
