### PR TITLE
[Bug] release version에서 "v" 제거

### DIFF
--- a/.github/workflows/prod-build-image.yaml
+++ b/.github/workflows/prod-build-image.yaml
@@ -3,7 +3,7 @@ name: Build docker image on release tag created
 on:
   push:
     tags:
-      - v**
+      - **
 
 jobs:
   build:


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #174 
기존처럼 release tag에서 "v"를 제거합니다.

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

없음.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
