### PR TITLE
Fix client side share routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import { PrivateRoute, PublicRoute } from "hoc/AuthRoutes";
 import pToP from "hoc/paramsToProps";
 
 import AppWrapper from "./App.styled";
+import Reload from "./components/pages/Reload";
 
 const App = () => (
   <AppWrapper>
@@ -55,6 +56,7 @@ const App = () => (
         <PrivateRoute path="/settings" component={SettingsPage} />
         <PublicRoute path="/auth" component={AuthPage} />
         <Route path="/api" component={ApiPage} />
+        <Route path="/s" component={Reload} />
         <Route path="/" exact component={LandingPage} />
         <Route path="/main" exact component={HomePage} />
         <Route path="/:name" component={ProfilePage} />

--- a/src/components/pages/Reload.tsx
+++ b/src/components/pages/Reload.tsx
@@ -1,0 +1,11 @@
+import React, { useEffect } from "react";
+
+const Reload: React.FC = () => {
+  useEffect(() => {
+    location.reload();
+  }, []);
+
+  return <></>;
+};
+
+export default Reload;

--- a/src/components/pages/index.ts
+++ b/src/components/pages/index.ts
@@ -26,3 +26,4 @@ export const NotFound = loadable(/* webpackPrefetch: true */ () => import("./Not
 // export const AdminPage = loadable(/* webpackPrefetch: true */ () => import("./AdminPage"));
 export const SearchPage = loadable(/* webpackPrefetch: true */ () => import("./SearchPage"));
 export const ApiPage = loadable(/* webpackPrefetch: true */ () => import("./ApiPage"));
+export const ReloadPage = loadable(/* webpackPrefetch: true */ () => import("./Reload"));


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #184 

# Extra info <!-- Answer 'y' or 'n'. 필요하지 않으면 지우셔도 됩니다. -->

React router 단에서 `/s` route가 핸들링되는 경우 `location.reload()`를 통해 강제로 서버 쪽으로 다시 요청을 보내도록 하였습니다.
재현이 되지 않는 버그라 완전히 테스트되지는 않았지만, 클라이언트 쪽(`react-router-dom`의 `Link` 이용)에서 접근하려고 시도했을 dev proxy 쪽으로 다시 연결되는 것까지 확인하였습니다.
